### PR TITLE
Move factory.stopTrying() from Component.startService to Component.stopService method

### DIFF
--- a/wokkel/component.py
+++ b/wokkel/component.py
@@ -65,12 +65,12 @@ class Component(StreamManager, service.Service):
     def startService(self):
         service.Service.startService(self)
 
-        self.factory.stopTrying()
         self._connection = self._getConnection()
 
     def stopService(self):
         service.Service.stopService(self)
 
+        self.factory.stopTrying()
         self._connection.disconnect()
 
     def _getConnection(self):


### PR DESCRIPTION
Calling `factory.stopTrying()` from `Component.startService` method prevented component from retrying to establish connection if first attempt (triggered by `.serviceStart`) failed. Component would try to reestablish connection if the initial one was lost though.

I assume `stopTrying` call is a mistake, since `XMPPClient` implements `startService` and `stopService` methods in a similar way, but calls `stopTrying` from `stopService`, as expected. Am I missing something?
