### PR TITLE
Support for Client to Server pings

### DIFF
--- a/wokkel/ping.py
+++ b/wokkel/ping.py
@@ -30,11 +30,11 @@ class PingClientProtocol(XMPPHandler):
     This handler implements the protocol for sending out XMPP Ping requests.
     """
 
-    def ping(self, entity, sender=None):
+    def ping(self, entity=None, sender=None, timeout=None):
         """
         Send out a ping request and wait for a response.
 
-        @param entity: Entity to be pinged.
+        @param entity: Entity to be pinged. L{None} to ping the server.
         @type entity: L{JID<twisted.words.protocols.jabber.jid.JID>}
 
         @return: A deferred that fires upon receiving a response.
@@ -42,6 +42,9 @@ class PingClientProtocol(XMPPHandler):
 
         @param sender: Optional sender address.
         @type sender: L{JID<twisted.words.protocols.jabber.jid.JID>}
+
+        @param entity: timeout in seconds for the ping to be responded before errback is called.
+        @type entity: L{int}
         """
         def cb(response):
             return None
@@ -60,7 +63,13 @@ class PingClientProtocol(XMPPHandler):
         if sender is not None:
             request['from'] = sender.full()
 
-        d = request.send(entity.full())
+        if timeout is not None:
+            request.timeout = timeout
+
+        if entity is None:
+            d = request.send()
+        else:
+            d = request.send(entity.full())
         d.addCallbacks(cb, eb)
         return d
 

--- a/wokkel/test/test_ping.py
+++ b/wokkel/test/test_ping.py
@@ -51,6 +51,26 @@ class PingClientProtocolTest(unittest.TestCase):
 
         return d
 
+    def test_pingToServer(self):
+        """
+                Pinging a service should fire a deferred with None
+                """
+
+        def cb(result):
+            self.assertIdentical(None, result)
+
+        d = self.protocol.ping()
+        d.addCallback(cb)
+
+        iq = self.stub.output[-1]
+        self.assertIsNone(iq.getAttribute(u'to'))
+        self.assertEqual(u'get', iq.getAttribute(u'type'))
+        self.assertEqual('urn:xmpp:ping', iq.ping.uri)
+
+        response = toResponse(iq, u'result')
+        self.stub.send(response)
+
+        return d
 
     def test_pingWithSender(self):
         """


### PR DESCRIPTION
XEP-0199 describes client to server pings. In this pull request client support for these types of pings is added. 

Additionally the ping() method now has an optional timeout parameter. Pings that have not been responded in timeout time will call the errback on the deferred. 

REF: https://xmpp.org/extensions/xep-0199.html#c2s
